### PR TITLE
Adjust display on Resources page for Explore resource boxes

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -302,7 +302,8 @@ ul li {font-weight:normal;}}
 ul.resource-list>li ul {
     list-style:none;
     padding-left:1rem;
-    margin-top:1rem;
+    margin-top:0.5rem;
+    margin-bottom:1rem;
     border-left:1px solid var(--list-border);
     font-size:1rem;
     li {margin-bottom:1em}
@@ -401,22 +402,24 @@ div.community-growth-items {
   gap:1.5em;
   margin-bottom:2em;
 
-@media (min-width: 35em) {
+  @media (min-width: 65em) {
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(1, 1fr);
+    .resource-section:nth-child(1) { grid-area: 1 / 1 / 2 / 2; }
+    .resource-section:nth-child(2) { grid-area: 1 / 2 / 2 / 3; }
+    .resource-section:nth-child(3) { grid-area: 2 / 1 / 3 / 3; }    
+  }
 
-  grid-auto-flow: column;
-  grid-auto-columns: 1fr;
 }
 
-}
 .resource-list-container {
   display:grid;
   gap:1.5em;
 
-@media (min-width: 70em) {
-
-  grid-auto-flow: column;
-  grid-auto-columns: 1fr;
-}
+  @media (min-width: 70em) {
+    grid-auto-flow: column;
+    grid-auto-columns: 1fr;
+  }
 
 }
 .resource-section {
@@ -431,17 +434,23 @@ div.community-growth-items {
   ul li::marker {color:#ccc}
   
   section {
-  margin:1.5em 0;
-  border-bottom:1px solid var(--box-border);
+    margin:1.5em 0;
+    border-bottom:1px solid var(--box-border);
   }
-  .title {display:flex;align-content:baseline; align-items:baseline;justify-content: space-between;
-  a {
-  font-size:1rem;
+  .title {
+    display:flex;
+    align-content:baseline;
+    align-items:baseline;
+    justify-content: space-between;
+    a {
+      font-size:1rem;
+    }
   }
-
+  h4 a {
+    text-decoration:none;
   }
-  h4 a {text-decoration:none;}
 }
+
 .playbook-roles {
   .role-sections-list {
     border-top:1px solid var(--box-border);
@@ -450,10 +459,16 @@ div.community-growth-items {
     margin-left:0;
     padding-left:0;
     li {margin-bottom:0.5em}
-    a.sub {padding-left:1em; border-left:1px solid var(--box-border)}
+    a.sub {
+      padding-left:1em;
+      border-left:1px solid var(--box-border);
     }
-  .role-row {margin-top:1em;margin-bottom:1em;}  
-  .role-row h3 {margin-top:0}
+  }
+  .role-row {
+    margin-top:1em;
+    margin-bottom:1em;  
+    h3 {margin-top:0}
+  }
 }
 
 


### PR DESCRIPTION
The "Explore" boxes: By Role, Tech Deep Dives, Tools, are shown in 3 very narrow boxes now that the Playbook mega menu is added to the left side. This CSS adjusts the display so these boxes behave better. Tools gets double wide because its content is much longer than the other two sections.